### PR TITLE
Add init command for shell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A fast, interactive AWS profile and region switcher. Like [kubectx](https://github.com/ahmetb/kubectx) for AWS.
 
-> **Status:** Early development — profile listing and switching work, interactive picker and shell integration coming soon.
+> **Status:** Early development — profile listing, switching, and shell integration work. Interactive picker coming soon.
 
 ## Usage
 
 ```bash
 awss list              # list all profiles
-awss <name>            # switch to named profile (coming soon)
+awss <name>            # switch to named profile (requires shell integration)
 awss -                 # switch to previous profile (coming soon)
 awss -c                # print current profile and region (coming soon)
 awss -r                # interactive region picker (coming soon)
@@ -19,8 +19,14 @@ awss -r                # interactive region picker (coming soon)
 `awss` sets `AWS_PROFILE` (and optionally `AWS_REGION`) in your current shell via a thin shell wrapper. It does not resolve or cache credentials — the AWS SDK handles that transparently.
 
 ```bash
-# Add to your .bashrc / .zshrc:
-source <(awss init bash)   # or zsh/fish
+# Bash — add to ~/.bashrc:
+eval "$(awss init bash)"
+
+# Zsh — add to ~/.zshrc:
+eval "$(awss init zsh)"
+
+# Fish — add to ~/.config/fish/config.fish:
+awss init fish | source
 ```
 
 ## Install

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}
+
+var initCmd = &cobra.Command{
+	Use:       "init <shell>",
+	Short:     "Output shell integration code",
+	Long:      "Print a shell wrapper function for awss. Source the output in your shell config file.",
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"bash", "zsh", "fish"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		shell := args[0]
+
+		exe, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolving executable path: %w", err)
+		}
+		exe, err = filepath.EvalSymlinks(exe)
+		if err != nil {
+			return fmt.Errorf("resolving symlinks: %w", err)
+		}
+
+		out, err := renderInit(shell, exe)
+		if err != nil {
+			return err
+		}
+		fmt.Print(out)
+		return nil
+	},
+}
+
+type initData struct {
+	BinaryPath string
+	Shell      string
+	ConfigFile string
+}
+
+const posixTmpl = `# awss shell integration
+# Add to your ~/{{.ConfigFile}}:
+#   eval "$({{.BinaryPath}} init {{.Shell}})"
+
+awss() {
+  case "$1" in
+    ""|init|list|--help|-h)
+      command "{{.BinaryPath}}" "$@"
+      return $?
+      ;;
+  esac
+  local output
+  output=$(command "{{.BinaryPath}}" select "$@")
+  local exit_code=$?
+  if [ $exit_code -eq 0 ]; then
+    eval "$output"
+  fi
+  return $exit_code
+}
+`
+
+const fishTmpl = `# awss shell integration
+# Add to your ~/.config/fish/{{.ConfigFile}}:
+#   {{.BinaryPath}} init fish | source
+
+function awss
+  switch "$argv[1]"
+    case '' init list --help -h
+      command "{{.BinaryPath}}" $argv
+      return $status
+  end
+  set -l output (command "{{.BinaryPath}}" select --shell fish $argv)
+  set -l cmd_status $status
+  if test $cmd_status -eq 0
+    eval $output
+  end
+  return $cmd_status
+end
+`
+
+func renderInit(shell, binaryPath string) (string, error) {
+	var tmplStr string
+	var data initData
+
+	data.BinaryPath = binaryPath
+	data.Shell = shell
+
+	switch shell {
+	case "bash":
+		tmplStr = posixTmpl
+		data.ConfigFile = ".bashrc"
+	case "zsh":
+		tmplStr = posixTmpl
+		data.ConfigFile = ".zshrc"
+	case "fish":
+		tmplStr = fishTmpl
+		data.ConfigFile = "config.fish"
+	default:
+		return "", fmt.Errorf("unsupported shell: %q (valid: bash, zsh, fish)", shell)
+	}
+
+	tmpl, err := template.New("init").Parse(tmplStr)
+	if err != nil {
+		return "", fmt.Errorf("parsing template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing template: %w", err)
+	}
+	return buf.String(), nil
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderInit_Bash(t *testing.T) {
+	out, err := renderInit("bash", "/usr/local/bin/awss")
+	if err != nil {
+		t.Fatalf("renderInit(bash) error: %v", err)
+	}
+	for _, want := range []string{
+		"awss()",
+		"/usr/local/bin/awss",
+		".bashrc",
+		`eval "$(`,
+		`command "/usr/local/bin/awss" select "$@"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bash output missing %q", want)
+		}
+	}
+}
+
+func TestRenderInit_Zsh(t *testing.T) {
+	out, err := renderInit("zsh", "/usr/local/bin/awss")
+	if err != nil {
+		t.Fatalf("renderInit(zsh) error: %v", err)
+	}
+	for _, want := range []string{
+		"awss()",
+		"/usr/local/bin/awss",
+		".zshrc",
+		"init zsh",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("zsh output missing %q", want)
+		}
+	}
+}
+
+func TestRenderInit_Fish(t *testing.T) {
+	out, err := renderInit("fish", "/usr/local/bin/awss")
+	if err != nil {
+		t.Fatalf("renderInit(fish) error: %v", err)
+	}
+	for _, want := range []string{
+		"function awss",
+		"/usr/local/bin/awss",
+		"config.fish",
+		"--shell fish",
+		"init fish | source",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("fish output missing %q", want)
+		}
+	}
+}
+
+func TestRenderInit_InvalidShell(t *testing.T) {
+	_, err := renderInit("powershell", "/usr/local/bin/awss")
+	if err == nil {
+		t.Fatal("expected error for invalid shell, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported shell") {
+		t.Errorf("error = %q, want it to contain 'unsupported shell'", err.Error())
+	}
+}

--- a/cmd/select.go
+++ b/cmd/select.go
@@ -8,7 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var shellFlag string
+
 func init() {
+	selectCmd.Flags().StringVar(&shellFlag, "shell", "", "output syntax: bash, zsh, or fish (default bash)")
 	rootCmd.AddCommand(selectCmd)
 }
 
@@ -30,8 +33,7 @@ var selectCmd = &cobra.Command{
 			return err
 		}
 
-		// TODO: Implement formatExports — see comment below.
-		fmt.Print(formatExports(profile))
+		fmt.Print(formatExports(profile, shellFlag))
 		return nil
 	},
 }
@@ -40,13 +42,23 @@ var selectCmd = &cobra.Command{
 //
 // Always emits AWS_PROFILE. Emits AWS_REGION when the profile defines one,
 // otherwise unsets it to prevent stale values from a previous switch.
-func formatExports(p config.Profile) string {
+// When shell is "fish", outputs fish-compatible set/set -e syntax.
+func formatExports(p config.Profile, shell string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "export AWS_PROFILE=%s\n", p.Name)
-	if p.Region != "" {
-		fmt.Fprintf(&b, "export AWS_REGION=%s\n", p.Region)
+	if shell == "fish" {
+		fmt.Fprintf(&b, "set -gx AWS_PROFILE %s\n", p.Name)
+		if p.Region != "" {
+			fmt.Fprintf(&b, "set -gx AWS_REGION %s\n", p.Region)
+		} else {
+			b.WriteString("set -e AWS_REGION\n")
+		}
 	} else {
-		b.WriteString("unset AWS_REGION\n")
+		fmt.Fprintf(&b, "export AWS_PROFILE=%s\n", p.Name)
+		if p.Region != "" {
+			fmt.Fprintf(&b, "export AWS_REGION=%s\n", p.Region)
+		} else {
+			b.WriteString("unset AWS_REGION\n")
+		}
 	}
 	return b.String()
 }

--- a/cmd/select_test.go
+++ b/cmd/select_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestFormatExports_WithRegion(t *testing.T) {
-	got := formatExports(config.Profile{Name: "production", Region: "us-east-1"})
+	got := formatExports(config.Profile{Name: "production", Region: "us-east-1"}, "")
 	want := "export AWS_PROFILE=production\nexport AWS_REGION=us-east-1\n"
 	if got != want {
 		t.Errorf("formatExports() =\n%s\nwant:\n%s", got, want)
@@ -15,7 +15,7 @@ func TestFormatExports_WithRegion(t *testing.T) {
 }
 
 func TestFormatExports_WithoutRegion(t *testing.T) {
-	got := formatExports(config.Profile{Name: "staging", Region: ""})
+	got := formatExports(config.Profile{Name: "staging", Region: ""}, "")
 	want := "export AWS_PROFILE=staging\nunset AWS_REGION\n"
 	if got != want {
 		t.Errorf("formatExports() =\n%s\nwant:\n%s", got, want)
@@ -23,8 +23,24 @@ func TestFormatExports_WithoutRegion(t *testing.T) {
 }
 
 func TestFormatExports_DefaultProfile(t *testing.T) {
-	got := formatExports(config.Profile{Name: "default", Region: "us-west-2"})
+	got := formatExports(config.Profile{Name: "default", Region: "us-west-2"}, "")
 	want := "export AWS_PROFILE=default\nexport AWS_REGION=us-west-2\n"
+	if got != want {
+		t.Errorf("formatExports() =\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatExports_Fish_WithRegion(t *testing.T) {
+	got := formatExports(config.Profile{Name: "production", Region: "us-east-1"}, "fish")
+	want := "set -gx AWS_PROFILE production\nset -gx AWS_REGION us-east-1\n"
+	if got != want {
+		t.Errorf("formatExports() =\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatExports_Fish_WithoutRegion(t *testing.T) {
+	got := formatExports(config.Profile{Name: "staging", Region: ""}, "fish")
+	want := "set -gx AWS_PROFILE staging\nset -e AWS_REGION\n"
 	if got != want {
 		t.Errorf("formatExports() =\n%s\nwant:\n%s", got, want)
 	}


### PR DESCRIPTION
## Summary

- Add `awss init bash|zsh|fish` command that outputs a shell wrapper function for seamless profile switching
- Add `--shell` flag to `select` command for fish-compatible export syntax (`set -gx` / `set -e`)
- Wrapper routes known subcommands (`list`, `init`, `--help`) directly to the binary; everything else goes through `select` + `eval`
- Update README with per-shell setup instructions

## Test plan

- [x] `go test ./...` — all 26 tests pass (9 cmd, 17 config)
- [x] `go vet ./...` and `golangci-lint run --enable gosec` — clean
- [x] `awss init bash` / `zsh` / `fish` — outputs valid shell code with correct binary path
- [x] `awss init powershell` — returns error with usage hint
- [x] `source <(awss init bash)` then `awss <profile>` — sets `$AWS_PROFILE` in current shell
- [x] `awss list` and `awss --help` pass through to binary after sourcing wrapper
- [x] `awss select production --shell fish` — outputs `set -gx` syntax

Closes #3